### PR TITLE
Alha dpupdate

### DIFF
--- a/src/com/hms_networks/americas/sc/datapoint/DataPointDword.java
+++ b/src/com/hms_networks/americas/sc/datapoint/DataPointDword.java
@@ -1,14 +1,14 @@
 package com.hms_networks.americas.sc.datapoint;
 
 /**
- * Long data point class
+ * DWORD data point class
  * <p>
- * Class object for a DataPoint with a long value
+ * Class object for a DataPoint with a DWORD value
  *
  * @since 1.0
  * @author HMS Networks, MU Americas Solution Center
  */
-public class DataPointLong extends DataPoint {
+public class DataPointDword extends DataPoint {
 
   /**
    * Data point value
@@ -16,12 +16,12 @@ public class DataPointLong extends DataPoint {
   private final long value;
 
   /**
-   * Constructor for a <code>long</code> data point.
+   * Constructor for a DWORD data point.
    *
    * @param value data point value
    * @param time data point timestamp
    */
-  public DataPointLong(long value, String time) {
+  public DataPointDword(long value, String time) {
     this.value = value;
     this.timestamp = time;
   }
@@ -43,8 +43,8 @@ public class DataPointLong extends DataPoint {
    */
   public boolean equals(DataPoint p) {
     boolean returnVal = false;
-    if (p instanceof DataPointLong) {
-      returnVal = p.getTimeStamp().equals(timestamp) && ((DataPointLong) p).getValue() == value;
+    if (p instanceof DataPointDword) {
+      returnVal = p.getTimeStamp().equals(timestamp) && ((DataPointDword) p).getValue() == value;
     }
     return returnVal;
   }
@@ -57,8 +57,8 @@ public class DataPointLong extends DataPoint {
    */
   public boolean valueEquals(DataPoint p) {
     boolean returnVal = false;
-    if (p instanceof DataPointLong) {
-      returnVal = ((DataPointLong) p).getValue() == value;
+    if (p instanceof DataPointDword) {
+      returnVal = ((DataPointDword) p).getValue() == value;
     }
     return returnVal;
   }
@@ -69,7 +69,7 @@ public class DataPointLong extends DataPoint {
    * @return data point type
    */
   public DataType getType() {
-    return DataType.LONG;
+    return DataType.DWORD;
   }
 
   /**

--- a/src/com/hms_networks/americas/sc/datapoint/DataPointFloat.java
+++ b/src/com/hms_networks/americas/sc/datapoint/DataPointFloat.java
@@ -1,19 +1,19 @@
 package com.hms_networks.americas.sc.datapoint;
 
 /**
- * Double data point class
+ * Float data point class
  * <p>
- * Class object for a DataPoint with a double value
+ * Class object for a DataPoint with a float value
  *
  * @since 1.0
  * @author HMS Networks, MU Americas Solution Center
  */
-public class DataPointDouble extends DataPoint {
+public class DataPointFloat extends DataPoint {
 
   /**
    * Data point value
    */
-  private final double value;
+  private final float value;
 
   /**
    * Constructor for a <code>double</code> data point.
@@ -21,7 +21,7 @@ public class DataPointDouble extends DataPoint {
    * @param value data point value
    * @param time data point timestamp
    */
-  public DataPointDouble(double value, String time) {
+  public DataPointFloat(float value, String time) {
     this.value = value;
     this.timestamp = time;
   }
@@ -43,9 +43,9 @@ public class DataPointDouble extends DataPoint {
    */
   public boolean equals(DataPoint p) {
     boolean returnVal = false;
-    if (p instanceof DataPointDouble) {
+    if (p instanceof DataPointFloat) {
       returnVal = p.getTimeStamp().equals(timestamp)
-          && ((DataPointDouble) p).getValue() == value;
+          && ((DataPointFloat) p).getValue() == value;
     }
     return returnVal;
   }
@@ -58,8 +58,8 @@ public class DataPointDouble extends DataPoint {
    */
   public boolean valueEquals(DataPoint p) {
     boolean returnVal = false;
-    if (p instanceof DataPointDouble) {
-      returnVal = ((DataPointDouble) p).getValue() == value;
+    if (p instanceof DataPointFloat) {
+      returnVal = ((DataPointFloat) p).getValue() == value;
     }
     return returnVal;
   }
@@ -70,7 +70,7 @@ public class DataPointDouble extends DataPoint {
    * @return data point type
    */
   public DataType getType() {
-    return DataType.DOUBLE;
+    return DataType.FLOAT;
   }
 
   /**

--- a/src/com/hms_networks/americas/sc/datapoint/DataType.java
+++ b/src/com/hms_networks/americas/sc/datapoint/DataType.java
@@ -15,9 +15,9 @@ public class DataType {
   private static final byte DATA_TYPE_BOOLEAN = 0;
 
   /**
-   * Byte assigned to represent the double data type.
+   * Byte assigned to represent the float data type.
    */
-  private static final byte DATA_TYPE_DOUBLE = 1;
+  private static final byte DATA_TYPE_FLOAT = 1;
 
   /**
    * Byte assigned to represent the integer data type.
@@ -42,7 +42,7 @@ public class DataType {
   /**
    * Public instance of {@link DataType} representing float data type.
    */
-  public static final DataType DOUBLE = new DataType(DATA_TYPE_DOUBLE);
+  public static final DataType FLOAT = new DataType(DATA_TYPE_FLOAT);
 
   /**
    * Public instance of {@link DataType} representing integer data type.

--- a/src/com/hms_networks/americas/sc/datapoint/DataType.java
+++ b/src/com/hms_networks/americas/sc/datapoint/DataType.java
@@ -25,9 +25,9 @@ public class DataType {
   private static final byte DATA_TYPE_INTEGER = 2;
 
   /**
-   * Byte assigned to represent the long type.
+   * Byte assigned to represent the DWORD type.
    */
-  private static final byte DATA_TYPE_LONG = 3;
+  private static final byte DATA_TYPE_DWORD = 3;
 
   /**
    * Byte assigned to represent the string data type.
@@ -50,9 +50,9 @@ public class DataType {
   public static final DataType INTEGER = new DataType(DATA_TYPE_INTEGER);
 
   /**
-   * Public instance of {@link DataType} representing long data type.
+   * Public instance of {@link DataType} representing DWORD data type.
    */
-  public static final DataType LONG = new DataType(DATA_TYPE_LONG);
+  public static final DataType DWORD = new DataType(DATA_TYPE_DWORD);
 
   /**
    * Public instance of {@link DataType} representing string data type.


### PR DESCRIPTION
Aligned the datapoint classes with the data types available on the Ewon. In the case of DWORD, made the DWORD datapoint class as close as possible. Internally, it uses a long, which is large enough to store a DWORD value without loss.