### PR TITLE
Dev/1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Flexy Data Point Library Changelog
 
+## Version 1.2.1
+### Features
+- N/A
+### Bug Fixes
+- Fixed a bug where integer mapped string data points return the incorrect data type
+### Other
+- N/A
+
 ## Version 1.2
 ### Features
 - Added integer mapped string data point type

--- a/src/com/hms_networks/americas/sc/datapoint/DataPointIntegerMappedString.java
+++ b/src/com/hms_networks/americas/sc/datapoint/DataPointIntegerMappedString.java
@@ -52,4 +52,13 @@ public class DataPointIntegerMappedString extends DataPointString {
       String tagName, int tagId, int value, String time, String[] enumMapping) {
     super(tagName, tagId, enumMapping[value], time);
   }
+
+  /**
+   * Get the data point type.
+   *
+   * @return data point type
+   */
+  public DataType getType() {
+    return DataType.INTEGER_MAPPED_STRING;
+  }
 }

--- a/src/com/hms_networks/americas/sc/datapoint/DataType.java
+++ b/src/com/hms_networks/americas/sc/datapoint/DataType.java
@@ -23,6 +23,9 @@ public class DataType {
   /** Byte assigned to represent the string data type. */
   private static final byte DATA_TYPE_STRING = 4;
 
+  /** Byte assigned to represent the integer mapped string data type. */
+  private static final byte DATA_TYPE_INTEGER_MAPPED_STRING = 5;
+
   /** Public instance of {@link DataType} representing boolean data type. */
   public static final DataType BOOLEAN = new DataType(DATA_TYPE_BOOLEAN);
 
@@ -37,6 +40,10 @@ public class DataType {
 
   /** Public instance of {@link DataType} representing string data type. */
   public static final DataType STRING = new DataType(DATA_TYPE_STRING);
+
+  /** Public instance of {@link DataType} representing integer mapped string data type. */
+  public static final DataType INTEGER_MAPPED_STRING =
+      new DataType(DATA_TYPE_INTEGER_MAPPED_STRING);
 
   /** Instance data type. */
   private final byte instanceDataType;

--- a/src/com/hms_networks/americas/sc/datapoint/package.html
+++ b/src/com/hms_networks/americas/sc/datapoint/package.html
@@ -3,7 +3,7 @@
 Data point classes for storing information related to
 and the contents of data points from the Ewon historical log.
 
-@version 1.2
+@version 1.2.1
 @author HMS Networks, MU Americas Solution Center
 </BODY>
 </HTML>


### PR DESCRIPTION
This release adds the ability to differentiate between a regular string data point and an integer mapped string data point. 

Originally, I omitted an additional data type for this because the raw data returned from both data point classes is a string. In an implementation, not having the additional data type can manifest as a limitation or bug, because it prevents differentiating between a regular string and an integer mapped string. Some implementations may require this differentiation to properly represent the data to an endpoint.